### PR TITLE
Fixes + new stats

### DIFF
--- a/BetterFisher.lua
+++ b/BetterFisher.lua
@@ -35,9 +35,29 @@ else
 	Bot.UsedTimezone = "%X"
 end
 
+function Bot.ResetStats()
+	Bot.Stats = {
+		Loots = 0,
+		AverageLootTime = 0,
+		LootQuality = {},
+		Fishes = 0,
+		Shards = 0,
+		Keys = 0,
+		Trashs = 0,
+		LootTimeCount = 0,
+		LastLootTick = 0,
+		TotalLootTime = 0,
+		SessionStart = 0,
+		TotalSession = 0,
+	}
+end
+
+Bot.ResetStats()
+
 function Bot.Start()
 	if not Bot.Running then
-		Bot.ResetStats()
+		Bot.Stats.SessionStart = Pyx.System.TickCount
+		-- Bot.ResetStats() --Only manual reset for long time stats with player interactions ?
 		Bot.SaveSettings()
 
 		Bot.RepairState.Forced = false
@@ -66,7 +86,7 @@ function Bot.Start()
 		Bot.InventoryDeleteState.ItemCheckFunction = Bot.DeleteItemCheck
 
 		Bot.ConsumablesState.CustomCondition = Bot.ConsumablesCustomRunCheck
-		Bot.ConsumablesState:ClearTimers()
+		-- Bot.ConsumablesState:ClearTimers() --In case timer is set at more than 30min, the bot will use an other food while the buff is still active.
 		Bot.ConsumablesState.Settings.PreConsumeWait = 2
 		Bot.ConsumablesState.Settings.ConsumeWait = 8
 		Bot.ConsumablesState.ValidActions = { "WAIT" }
@@ -139,18 +159,7 @@ function Bot.Stop()
 	Bot.WarehouseState:Reset()
 	Bot.VendorState:Reset()
 	Bot.TradeManagerState:Reset()
-end
-
-function Bot.ResetStats()
-	Bot.Stats = {
-		Loots = 0,
-		AverageLootTime = 0,
-		LootQuality = {},
-		Fishes = 0,
-		Shards = 0,
-		Keys = 0,
-		Trashs = 0,
-	}
+	Bot.Stats.TotalSession = Bot.Stats.TotalSession + (Pyx.System.TickCount - Bot.Stats.SessionStart)
 end
 
 function Bot.OnPulse()

--- a/Gui/BotSettings.lua
+++ b/Gui/BotSettings.lua
@@ -98,7 +98,7 @@ function BotSettings.DrawBotSettings()
 		if ImGui.CollapsingHeader("Inventory Management", "id_gui_inv_manage", true, false) then
 			_, Bot.Settings.DeleteUsedRods = ImGui.Checkbox("##id_guid_inv_manage_autodelete_broken_rods", Bot.Settings.DeleteUsedRods)
 			ImGui.SameLine()
-			ImGui.Text("Auto delete broken Fishing Rods")
+			ImGui.Text("Auto delete broken (Steel) Fishing Rods")
 
 			ImGui.Text("Always delete these items")
 			valueChanged, BotSettings.InventoryComboSelectedIndex = ImGui.Combo("##id_guid_inv_manage_inventory_combo_select", BotSettings.InventoryComboSelectedIndex, BotSettings.InventoryName)

--- a/Gui/MainWindow.lua
+++ b/Gui/MainWindow.lua
@@ -19,7 +19,7 @@ function MainWindow.DrawMainWindow()
 
 		if ImGui.BeginPopup("Confirm") then
 			ImGui.TextColored(ImVec4(1,0.20,0.20,1) ,"WARNING!")
-			ImGui.Text("From default all \"Fishing Rods\" (just the basic white one),\nis deleted when 0 durability is reached, because cannot be repaired.")
+			ImGui.Text("By default all \"Fishing Rods\" and \"Steel Fishing Rods\",\nwill be deleted on 0 durability because they can't be repaired.")
 			ImGui.Spacing()
 			if ImGui.Button("Continue##btn_ok_start_bot", ImVec2(ImGui.GetContentRegionAvailWidth() / 3, 20)) then
 				Bot.Start()

--- a/Gui/Stats.lua
+++ b/Gui/Stats.lua
@@ -12,13 +12,19 @@ Stats.Visible = false
 function Stats.DrawStats()
 	if Stats.Visible then
 		_, Stats.Visible = ImGui.Begin("Loot Stats", Stats.Visible, ImVec2(350, 220), -1.0)
-
-		-- if Bot.Running then
-			-- t = Bot.FishingTime
-			-- s = math.fmod(t, 60)
-			-- m = math.fmod(t, 60 * 60) / 60
-			-- h = math.floor(t / 60 / 60)
-		-- end
+		
+		if h == nil then
+			h = 0
+			m = 0
+			s = 0
+		end
+		
+		if Bot.Running then
+			t = math.ceil((Bot.Stats.TotalSession + Pyx.System.TickCount - Bot.Stats.SessionStart) / 1000)
+			s = t % 60
+			m = math.floor(t / 60) % 60
+			h = math.floor(t / (60 * 60))
+		end
 
 		if Bot.Stats.Loots > 0 then
 			statsWhites = string.format("%i - %.02f%%%%", Bot.Stats.LootQuality[0] or 0, (Bot.Stats.LootQuality[0] or 0) / Bot.Stats.Loots * 100)
@@ -42,20 +48,12 @@ function Stats.DrawStats()
 			statsShards = "0 - 0.00%%"
 		end
 
-		ImGui.Columns(1) -- 2
-		ImGui.Text("Loot Taken: " .. string.format("%i", Bot.Stats.Loots))
-		-- ImGui.NextColumn()
-		-- if Bot.Running then
-		-- 	if s ~= 0 then
-		-- 		if h > 0 then
-		-- 			ImGui.Text("Fishing Time: " .. string.format("%.f:%02.f:%02.f", h, m, s))
-		-- 		else
-		-- 			ImGui.Text("Fishing Time: " .. string.format("%.f:%02.f", m, s))
-		-- 		end
-		-- 	end
-		-- else
-		-- 	ImGui.Text("Fishing Time: 0:00")
-		-- end
+		ImGui.Columns(3)
+		ImGui.Text("Time " .. string.format("%02.f:%02.f:%02.f", h, m, s))	
+		ImGui.NextColumn()
+		ImGui.Text("Loots: " .. string.format("%i", Bot.Stats.Loots))
+		ImGui.NextColumn()
+		ImGui.Text("Avg.: " .. Bot.Stats.AverageLootTime .. "s")
 
 		ImGui.Columns(1)
 		ImGui.Separator()

--- a/States/Loot.lua
+++ b/States/Loot.lua
@@ -46,7 +46,7 @@ function LootState:NeedToRun()
 		return false
 	end
 
-	return Looting.IsLooting
+	return Looting.IsLooting and selfPlayer.CurrentActionName == "WAIT"
 end
 
 function LootState:Run()
@@ -64,6 +64,9 @@ function LootState:Run()
 		for i = 0, numLoots -1, x do -- for i = 0, numLoots -1 do
 			local lootItem = Looting.GetItemByIndex(i)
 			local lootItemName = lootItem.ItemEnchantStaticStatus.Name
+			if string.find(lootItemName,"Moray") then --Fix because some names contains weird characters
+				lootItemName = "Moray"
+			end
 			local lootItemType = "Trash"
 			local lootItemQuality = nil
 
@@ -199,13 +202,22 @@ function LootState:Run()
 				end
 			end
 
+			local FishGameTime = "- "
+			if Bot.Stats.LastLootTick ~= 0 then
+				Bot.Stats.LootTimeCount = Bot.Stats.LootTimeCount + 1
+				FishGameTime = Pyx.System.TickCount - Bot.Stats.LastLootTick
+				Bot.Stats.TotalLootTime = Bot.Stats.TotalLootTime + FishGameTime
+				FishGameTime = math.ceil(FishGameTime/1000)
+				Bot.Stats.AverageLootTime = math.ceil((Bot.Stats.TotalLootTime/Bot.Stats.LootTimeCount)/1000)
+			end
+			
 			if self.LootingState == 4 then -- 4 = loot the item
-				print("[" .. os.date(Bot.UsedTimezone) .. "] Looted: " .. lootItemName .. " [" .. lootItemType .. "] (" .. lootItemQuality .. ")")
+				print("[" .. os.date(Bot.UsedTimezone) .. "] Looted: " .. lootItemName .. " [" .. lootItemType .. "] (" .. lootItemQuality .. ") Time : " .. FishGameTime .. "s")
 				Looting.Take(i)
 			end
 
 			if self.LootingState == 5 then -- 5 = don't loot the item
-				print("[" .. os.date(Bot.UsedTimezone) .. "] Not looted: " .. lootItemName .. " [" .. lootItemType .. "] (" .. lootItemQuality .. ")")
+				print("[" .. os.date(Bot.UsedTimezone) .. "] Not looted: " .. lootItemName .. " [" .. lootItemType .. "] (" .. lootItemQuality .. ") Time : " .. FishGameTime .. "s")
 			end
 		end
 	--end

--- a/States/Repair.lua
+++ b/States/Repair.lua
@@ -70,7 +70,9 @@ function RepairState:NeedToRun()
 
 	if not equippedItem then
 		for k,v in pairs(selfPlayer.Inventory.Items) do
-			if v.HasEndurance and v.EndurancePercent <= 0 and (v.ItemEnchantStaticStatus.IsFishingRod and v.ItemEnchantStaticStatus.ItemId ~= 16141) then
+			if v.HasEndurance and v.EndurancePercent <= 0 and 
+					(v.ItemEnchantStaticStatus.IsFishingRod and (v.ItemEnchantStaticStatus.ItemId ~= 16141 and v.ItemEnchantStaticStatus.ItemId ~= 16151)) 
+			then
 				if Navigator.CanMoveTo(self:GetPosition()) then
 					self.Forced = true
 					return true
@@ -82,7 +84,9 @@ function RepairState:NeedToRun()
 		end
 	else
 		for k,v in pairs(selfPlayer.EquippedItems) do
-			if v.HasEndurance and v.EndurancePercent <= 0 and (v.ItemEnchantStaticStatus.IsFishingRod and v.ItemEnchantStaticStatus.ItemId ~= 16141) then
+			if v.HasEndurance and v.EndurancePercent <= 0 and
+					(v.ItemEnchantStaticStatus.IsFishingRod and (v.ItemEnchantStaticStatus.ItemId ~= 16141 and v.ItemEnchantStaticStatus.ItemId ~= 16151)) 
+			then
 				if Navigator.CanMoveTo(self:GetPosition()) then
 					self.Forced = true
 					return true

--- a/States/StartFishing.lua
+++ b/States/StartFishing.lua
@@ -136,10 +136,11 @@ function StartFishingState:NeedToRun()
 		Bot.Stop()
 	end
 
-	return selfPlayer.CurrentActionName == "WAIT"
+	return selfPlayer.CurrentActionName == "WAIT" and not Looting.IsLooting
 end
 
 function StartFishingState:Run()
+	Bot.Stats.LastLootTick = Pyx.System.TickCount
 	local selfPlayer = GetSelfPlayer()
 
 	if Bot.Settings.OnBoat and selfPlayer.Inventory.FreeSlots == 0 then

--- a/States/TradeManager.lua
+++ b/States/TradeManager.lua
@@ -65,7 +65,9 @@ function TradeManagerState:NeedToRun()
 		return false
 	end
 
-	if 	self.Settings.TradeManagerOnInventoryFull and selfPlayer.Inventory.FreeSlots <= 3 and table.length(self:GetItems()) > 0 and Navigator.CanMoveTo(self:GetPosition()) then
+	if 	self.Settings.TradeManagerOnInventoryFull and selfPlayer.Inventory.FreeSlots <= 3 and 
+			table.length(self:GetItems()) > 0 and Navigator.CanMoveTo(self:GetPosition()) and not Looting.IsLooting
+	then
 		self.Forced = true
 		return true
 	end

--- a/States/Warehouse.lua
+++ b/States/Warehouse.lua
@@ -203,7 +203,6 @@ function WarehouseState:Run()
 				self.DepositedMoney = true
 				self.SleepTimer = PyxTimer:New(3)
 				self.SleepTimer:Start()
-				return
 			end
 
 			self.DepositedMoney = true


### PR DESCRIPTION
- Fixed warehouse deposit (something was omitted in the last commit, no
item deposit after gold deposit)
- Smoother animation while fishing (added some delay before looting the
items)
- Bot will not try to repair Steel Fishing Rods anymore
- Typos
- Disabled stats reset on start bot, you now have to reset it manually.
(Usefull to get stats on long fishing session where you have to
pause/start the bot without loosing the stats)
- Disbled consumable timer reset on start bot. (If you have a 90min
timer on food, the bot would use it after 30min if you had to
pause/start the bot for any reason -> waste of $$)
- Added average time/loot in the stats and log
- Added total fishing time