### PR TITLE
New nav fixes

### DIFF
--- a/BetterFisher.lua
+++ b/BetterFisher.lua
@@ -500,6 +500,7 @@ function Bot.LoadSettings()
 end
 
 function Bot.StateMoving(state)
+	local selfPlayer = GetSelfPlayer()
 	if Bot.CheckIfRodIsEquipped() then
 		selfPlayer:UnequipItem(INVENTORY_SLOT_RIGHT_HAND)
 	end
@@ -523,7 +524,7 @@ function Bot.StateComplete(state)
 	elseif Bot.Settings.RepairSettings.Enabled then
 		if state == Bot.WarehouseState then
 			if 	Bot.Settings.RepairSettings.RepairMethod == Bot.RepairState.SETTINGS_ON_REPAIR_AFTER_WAREHOUSE or	-- RepairMethod = 0
-				Bot.Settings.RepairSettings.RepairMethod == Bot.RepairState.SETTINGS_ON_REPAIR_AFTER_TRADER then	-- RepairMethod = 1
+				Bot.Settings.RepairSettings.RepairMethod == Bot.RepairState.SETTINGS_ON_REPAIR_AFTER_TRADER			-- RepairMethod = 1
 			then
 				Bot.RepairState.Forced = true
 			end
@@ -574,7 +575,7 @@ function Bot.CheckIfRodIsEquipped()
 	local selfPlayer = GetSelfPlayer()
 	local equippedItem = selfPlayer:GetEquippedItem(INVENTORY_SLOT_RIGHT_HAND)
 
-	if equippedItem ~= nil and equippedItem.ItemEnchantStaticStatus.IsFishingRod then then
+	if equippedItem ~= nil and equippedItem.ItemEnchantStaticStatus.IsFishingRod then
 		return true
 	end
 
@@ -592,6 +593,7 @@ function Bot.DeleteItemCheck(item)
 end
 
 function Bot.ConsumablesCustomRunCheck()
+	local selfPlayer = GetSelfPlayer()
 	if selfPlayer.CurrentActionName == "WAIT" then
 		if Bot.CheckIfRodIsEquipped() then
 			return true

--- a/Data/Settings.lua
+++ b/Data/Settings.lua
@@ -18,7 +18,7 @@ function Settings.new()
 	self.InvFullStop = false
 	self.UseAutorun = false
 	self.UseAutorunDistance = 800
-	self.FishingSpotRadius = 250
+	self.FishingSpotRadius = 300
 	self.StopWhenPeopleNearby = false
 	self.StopWhenPeopleNearbyDistance = 5000
 	self.PauseWhenPeopleNearby = false
@@ -32,11 +32,5 @@ function Settings.new()
 	self.StartFishingSettings = {}
 	self.HookFishHandleGameSettings = {}
 	self.LootSettings = {}
-<<<<<<< HEAD
-	self.UseAutorun = false
-	self.UseAutorunDistance = 800
-	self.FishingSpotRadius = 300
-=======
->>>>>>> develop
 	return self
 end

--- a/Data/Settings.lua
+++ b/Data/Settings.lua
@@ -31,6 +31,6 @@ function Settings.new()
 	self.LootSettings = {}
 	self.UseAutorun = false
 	self.UseAutorunDistance = 800
-	self.FishingSpotRadius = 250
+	self.FishingSpotRadius = 300
 	return self
 end

--- a/Helpers/Navigator.lua
+++ b/Helpers/Navigator.lua
@@ -154,6 +154,10 @@ function Navigator.CanMoveTo(destination)
 	if not selfPlayer then
 		return false
 	end
+	
+	if Bot.Settings.UseAutorun and destination.Distance3DFromMe >= Bot.Settings.UseAutorunDistance then
+		return true
+	end
 
 	local waypoints = Navigator.GetPath(selfPlayer.Position, destination)
 	if waypoints == nil then

--- a/States/MoveToFishingSpot.lua
+++ b/States/MoveToFishingSpot.lua
@@ -29,7 +29,7 @@ function MoveToFishingSpotState:NeedToRun()
 		return false
 	end
 
-	if not Navigator.CanMoveTo(ProfileEditor.CurrentProfile:GetFishSpotPosition()) and not Bot.Settings.UseAutorun then
+	if not Navigator.CanMoveTo(ProfileEditor.CurrentProfile:GetFishSpotPosition()) then
 		return false
 	end
 

--- a/States/Repair.lua
+++ b/States/Repair.lua
@@ -63,15 +63,11 @@ function RepairState:NeedToRun()
 		self.Forced = false
 	end
 
-<<<<<<< HEAD
 	if not Navigator.CanMoveTo(self:GetPosition()) then
 		self.Forced = false
 	end
 
-	if not equippedItem then
-=======
 	if not selfPlayer:GetEquippedItem(INVENTORY_SLOT_RIGHT_HAND) then
->>>>>>> develop
 		for k,v in pairs(selfPlayer.Inventory.Items) do
 			if 	v.HasEndurance and v.EndurancePercent <= 0 and
 				(v.ItemEnchantStaticStatus.IsFishingRod and

--- a/States/Repair.lua
+++ b/States/Repair.lua
@@ -64,7 +64,7 @@ function RepairState:NeedToRun()
 		self.Forced = false
 	end
 
-	if not Navigator.CanMoveTo(self:GetPosition()) and not Bot.Settings.UseAutorun then
+	if not Navigator.CanMoveTo(self:GetPosition()) then
 		self.Forced = false
 	end
 
@@ -74,7 +74,7 @@ function RepairState:NeedToRun()
 				(v.ItemEnchantStaticStatus.IsFishingRod and
 				(v.ItemEnchantStaticStatus.ItemId ~= 16141 and v.ItemEnchantStaticStatus.ItemId ~= 16147 and v.ItemEnchantStaticStatus.ItemId ~= 16151))
 			then
-				if self:HasNpc() and (Navigator.CanMoveTo(self:GetPosition()) or Bot.Settings.UseAutorun) then
+				if self:HasNpc() and Navigator.CanMoveTo(self:GetPosition()) then
 					self.Forced = true
 				else
 					self.Forced = false
@@ -87,7 +87,7 @@ function RepairState:NeedToRun()
 				(v.ItemEnchantStaticStatus.IsFishingRod and
 				(v.ItemEnchantStaticStatus.ItemId ~= 16141 and v.ItemEnchantStaticStatus.ItemId ~= 16147 and v.ItemEnchantStaticStatus.ItemId ~= 16151))
 			then
-				if self:HasNpc() and (Navigator.CanMoveTo(self:GetPosition()) or Bot.Settings.UseAutorun) then
+				if self:HasNpc() and Navigator.CanMoveTo(self:GetPosition()) then
 					self.Forced = true
 				else
 					self.Forced = false


### PR DESCRIPTION
- Navigator.CanMoveTo() should return true if you are using autorun outside the autorun radius :D
- You can now use the new autorun system with only the NPCs / Fish spots meshed. Don't need to mesh all the path nor to connect meshes :P