### PR TITLE
Fix for NPCs (NPC loop order)

### DIFF
--- a/States/Repair.lua
+++ b/States/Repair.lua
@@ -236,6 +236,10 @@ function RepairState:Run()
 	end
 
 	if self.state == 7 then -- 7 = state complete
+		if Bot.Settings.WarehouseSettings.DepositMethod == WarehouseState.SETTINGS_ON_DEPOSIT_AFTER_REPAIR then
+			Bot.WarehouseState.ManualForced = true
+			print("Forcing deposit after repair...")
+		end
 		if self.CallWhenCompleted then
 			self.CallWhenCompleted(self)
 		end

--- a/States/TradeManager.lua
+++ b/States/TradeManager.lua
@@ -266,6 +266,14 @@ function TradeManagerState:Run()
 	end
 
 	if self.state == 6 then -- 6 = state complete
+		if  Bot.Settings.RepairSettings.Enabled == true and Bot.Settings.RepairSettings.RepairMethod == RepairState.SETTINGS_ON_REPAIR_AFTER_TRADER then
+			Bot.RepairState.ManualForced = true
+			print("Forcing repair after trader...")
+		end
+		if Bot.Settings.WarehouseSettings.DepositMethod == WarehouseState.SETTINGS_ON_DEPOSIT_AFTER_TRADER then
+			Bot.WarehouseState.ManualForced = true
+			print("Forcing deposit after trader...")
+		end
 		if self.CallWhenCompleted then
 			self.CallWhenCompleted(self)
 		end

--- a/States/Vendor.lua
+++ b/States/Vendor.lua
@@ -280,6 +280,10 @@ function VendorState:Run()
 	end
 
 	if self.state == 6 then -- 6 = state complete
+		if Bot.Settings.WarehouseSettings.DepositMethod == WarehouseState.SETTINGS_ON_DEPOSIT_AFTER_VENDOR then
+			Bot.WarehouseState.ManualForced = true
+			print("Forcing deposit after vendor...")
+		end
 		if self.CallWhenCompleted then
 			self.CallWhenCompleted(self)
 		end

--- a/States/Warehouse.lua
+++ b/States/Warehouse.lua
@@ -222,6 +222,10 @@ function WarehouseState:Run()
 	end
 
 	if self.state == 5 then -- 5 = state complete
+		if  Bot.Settings.RepairSettings.Enabled == true and Bot.Settings.RepairSettings.RepairMethod == RepairState.SETTINGS_ON_REPAIR_AFTER_WAREHOUSE then
+			Bot.RepairState.ManualForced = true
+			print("Forcing repair after warehouse...")
+		end
 		if self.CallWhenCompleted then
 			self.CallWhenCompleted(self)
 		end


### PR DESCRIPTION
- Bot will now force NPCs based on settings. (For exemple, if you set "repair after deposit", the bot will always go to repair after warehouse NPC)